### PR TITLE
Undo "Revert "Link to GitHub help pages for terms in README""

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ A great example repo you can fork to your heart’s content, that serves as a la
 
 ## Getting started
 
-The first thing you want to do with this repo is quite likely **fork it**.  Use the Fork button in the top-right section of the page to do this.
+The first thing you want to do with this repo is quite likely [**fork it**](https://help.github.com/en/github/getting-started-with-github/fork-a-repo).  Use the Fork button in the top-right section of the page to do this.
 
-Once you’re on your fork, you can experiment however you like with it, play with branches, issues, milestones, labels, the wiki, and more.
+Once you’re on your fork, you can experiment however you like with it, play with [**branches**](https://help.github.com/en/github/administering-a-repository/viewing-branches-in-your-repository), [**issues**](https://help.github.com/en/github/managing-your-work-on-github/about-issues), [**milestones**](https://help.github.com/en/github/managing-your-work-on-github/associating-milestones-with-issues-and-pull-requests), [**labels**](https://help.github.com/en/github/managing-your-work-on-github/applying-labels-to-issues-and-pull-requests), the [**wiki**](https://help.github.com/en/github/building-a-strong-community/about-wikis), and more.
 
 ## What’s in there?
 


### PR DESCRIPTION
Reverts ryanpeugh/oreilly-github-demo#2 so that the links show up again.